### PR TITLE
mailcheck: fix problem when calling check_cmd with a variable in profile

### DIFF
--- a/foldercheck
+++ b/foldercheck
@@ -9,11 +9,20 @@ ORIG_CMD="$0 $*"
 MBLAZE=${MBLAZE-$HOME/.mblaze}
 profile="$MBLAZE/profile"
 
-date_fmt=$(mhdr -h FolderCheckDateFmt $profile)
-[ -z "$date_fmt" ] && date_fmt="%Y-%m-%d %H:%M"
-sleep=$(mhdr -h FolderCheckSleep $profile)
-[ -z "$sleep" ] && sleep=30
+getmblazeopt () {
+    [[ -n $1 ]] && mhdr -h $1 $profile | envsubst && return 0
+    return 1
+}
+
+check_cmd=$(getmblazeopt MailCheckCommand)
+check_cmd=${check_cmd:-"fdm -q fetch"}
+
+sleep=$(getmblazeopt FolderCheckSleep)
+sleep=${sleep:-30}
 default_sleep=$sleep
+
+date_fmt=$(getmblazeopt FolderCheckDateFmt)
+date_fmt=${date_fmt:-"%Y-%m-%d %H:%M"}
 
 TEMPFILES=""
 

--- a/mailcheck
+++ b/mailcheck
@@ -43,7 +43,7 @@ wakeup () {
 
 mailcheck () {
 	echo $(ts) checking ...
-	$(echo $check_cmd | envsubst)
+	${check_cmd}
 	if [ -n "${index_cmd}" ]; then
 		echo $(ts) indexing ...
 		${index_cmd}

--- a/mailcheck
+++ b/mailcheck
@@ -43,7 +43,7 @@ wakeup () {
 
 mailcheck () {
 	echo $(ts) checking ...
-	${check_cmd}
+	$(echo $check_cmd | envsubst)
 	if [ -n "${index_cmd}" ]; then
 		echo $(ts) indexing ...
 		${index_cmd}

--- a/mailcheck
+++ b/mailcheck
@@ -9,23 +9,37 @@ MBLAZE=${MBLAZE-$HOME/.mblaze}
 profile="$MBLAZE/profile"
 
 sleep=$1
-[ -z "$sleep" ] && sleep=$(mhdr -h MailCheckSleep $profile)
-[ -z "$sleep" ] && sleep=30
-check_cmd=$(mhdr -h MailCheckCommand $profile)
-[ -z "$check_cmd" ] && check_cmd="fdm -q fetch"
-check_lockf=$(mhdr -h MailCheckLockFile $profile)
-[ -z "$check_lockf" ] && check_lockf=$HOME/.fdm.lock
-index_cmd=$(mhdr -h MailCheckIndexCommand $profile)
-[ -z "$index_cmd" ] && index_cmd="mairix -p"
-[ "$index_cmd" = "-" ] && index_cmd=""
-date_fmt=$(mhdr -h MailCheckDateFmt $profile)
-[ -z "$date_fmt" ] && date_fmt="%Y-%m-%d %H:%M"
 
 sleeper_pid=0
 
 ts () {
 	date +"$date_fmt"
 }
+
+getmblazeopt () {
+    [[ -n $1 ]] && mhdr -h $1 $profile | envsubst && return 0
+    return 1
+}
+
+check_cmd=$(getmblazeopt MailCheckCommand)
+check_cmd=${check_cmd:-"fdm -q fetch"}
+
+sleep=${1:-$(getmblazeopt MailCheckSleep)}
+sleep=${sleep:-30}
+
+check_lockf=$(getmblazeopt MailCheckLockFile)
+check_lockf=${check_lockf:-"$HOME/.fdm.lock"}
+
+index_cmd=$(getmblazeopt MailCheckIndexCommand)
+index_cmd=${index_cmd:--}
+if [[ $index_cmd == "-" ]]; then
+    index_cmd=""
+else
+    index_cmd=${index_cmd:-"mairix -p"}
+fi
+
+date_fmt=$(getmblazeopt MailCheckDateFmt)
+date_fmt=${date_fmt:-"%Y-%m-%d %H:%M"}
 
 shleep () {
 	sleep $1 >/dev/null 2>&1 & sleeper_pid=$!

--- a/mdisplay
+++ b/mdisplay
@@ -27,8 +27,11 @@ args=
 use_xterm=0
 use_tmux=0
 
-[ -n $TMUX ] && use_tmux=1
-[ $use_tmux -eq 0 -a -n $DISPLAY ] && use_xterm=1
+if [ -n $TMUX ]; then
+ 	use_tmux=1
+elif [ ${use_tmux} -eq 0 -a -n $DISPLAY ]; then
+	use_xterm=1
+fi
 
 for arg in $*; do
 	case $arg in


### PR DESCRIPTION
See issue #1 on original project.

My $MBLAZE is set to /Users/x/.config/mail

In my mblaze profile, I customized MailCheckCommand to be: MailCheckCommand: fdm -f $MBLAZE/fdmrc -q fetch

My small fix permits this otherwise, mailcheck aborts.